### PR TITLE
Make sure we don't accidentally delete our download directory.

### DIFF
--- a/modules/ajaxPage.py
+++ b/modules/ajaxPage.py
@@ -454,7 +454,8 @@ class Ajax:
             files = self.RT.getFiles(torrent_id)
             if len(files) == 1:
                 #single file
-                if files[0].base_path == self.RT.getRootDir():
+                rootDir = os.path.abspath(os.path.expanduser(os.path.expandvars(self.RT.getRootDir())))
+                if files[0].base_path == rootDir:
                     delete = files[0].abs_path
                 else:
                     delete = files[0].base_path


### PR DESCRIPTION
Using the "Remove Torrent and Files" button for a single-file torrent from the Web UI accidentally removed my whole rTorrent download directory rather than the single file it was supposed to. This will prevent that (at least in my case, as I reproduced and tested the problem).
